### PR TITLE
Add build instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Binary packages are available on Ubuntu Launchpad [here](https://launchpad.net/~
     $ sudo apt-get update
     $ sudo apt-get install audiowaveform
 
+### Arch Linux
+
+There is an [`audiowaveform`](https://aur.archlinux.org/packages/audiowaveform) package available in the AUR.
+
 ### Mac OSX via Homebrew
 
 To install `audiowaveform` using Homebrew:


### PR DESCRIPTION
I added this program to the [AUR](https://aur.archlinux.org/) to make it easy to install/update for Arch Linux users. This commit just adds a link to the AUR package in the README.

Note that the AUR is not a binary distribution platform, the package there is effectively just a build script that grabs the source from this repo, builds, and installs it.

I'm happy to transfer ownership of the package to a member of this team if required.