### PR TITLE
rpm packaging spec added

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,17 @@ CMAKE_INSTALL_PREFIX=...` option when invoking `cmake` above.
 
     $ audiowaveform --help
 
+## Building packages
+
+### RPM package
+
+To build rpm package clone repository, [install package dependencies](#fedora) and run commands:
+
+    $ cd packaging/rpm
+    $ make rpm
+
+rpm-packages will be placed to packaging/rpm/RPMS.
+
 ## Command line options
 
 **audiowaveform** accepts the following command-line options:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ CMAKE_INSTALL_PREFIX=...` option when invoking `cmake` above.
 
 To build rpm package clone repository, [install package dependencies](#fedora) and run commands:
 
+    $ sudo yum install rpmdevtools
     $ cd packaging/rpm
     $ make rpm
 

--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -1,0 +1,7 @@
+rpm:
+	mkdir -p SOURCES
+	spectool --get-files --directory SOURCES/ SPECS/audiowaveform.spec
+	rpmbuild --define "_topdir %(pwd)" --define "_version %(cat ../../VERSION)" -bb SPECS/audiowaveform.spec
+
+clean:
+	rm -rf BUILD BUILDROOT RPMS SRPMS

--- a/packaging/rpm/SPECS/audiowaveform.spec
+++ b/packaging/rpm/SPECS/audiowaveform.spec
@@ -1,0 +1,40 @@
+%define		src	%{_topdir}/../../
+%define		google_test_version	1.8.0
+
+Name:           audiowaveform 
+Version:	%{_version}
+Release:        1%{?dist}
+Summary:        application that generates waveform data from either MP3, WAV, or FLAC format audio files
+
+License:        GNU GPL 3
+URL:            https://github.com/bbc/audiowaveform
+Source0:        https://github.com/google/googletest/archive/release-%{google_test_version}.tar.gz
+
+BuildRequires:  make cmake gcc-c++ libmad-devel libid3tag-devel libsndfile-devel gd-devel boost-devel 
+
+%description
+audiowaveform is a C++ command-line application that generates waveform data from either MP3, WAV, or FLAC format audio files. Waveform data can be used to produce a visual rendering of the audio, similar in appearance to audio editing applications.
+
+%prep
+%setup -q -n googletest-release-%{google_test_version}
+ln -sf `pwd`/googletest %{src}/
+ln -sf `pwd`/googlemock %{src}/
+
+%build
+mkdir build
+cd build
+cmake -D CMAKE_INSTALL_PREFIX=%{buildroot}/usr %{src}
+make
+
+
+%install
+cd build
+make install
+cd %{buildroot}
+find -type f | sed 's#^\.##g' > /tmp/%{name}-files.txt 
+
+
+%files -f /tmp/%{name}-files.txt
+%attr(555,-,-) /usr/bin/audiowaveform
+
+%changelog


### PR DESCRIPTION
New feature: rpm packaging spec added.
For CentOS 7 tested on master and 1.1.0 tag.