### PR TITLE
Up max sample rate to support 192kHz audio files

### DIFF
--- a/src/GdImageRenderer.cpp
+++ b/src/GdImageRenderer.cpp
@@ -43,7 +43,7 @@
 
 // Upper limits prevent numeric overflows in image rendering.
 
-const int MAX_SAMPLE_RATE   = 50000;
+const int MAX_SAMPLE_RATE   = 100000;
 const int MAX_ZOOM          = 2000000;
 const double MAX_START_TIME = 12 * 60 * 60; // 12 hours
 

--- a/src/GdImageRenderer.cpp
+++ b/src/GdImageRenderer.cpp
@@ -43,7 +43,7 @@
 
 // Upper limits prevent numeric overflows in image rendering.
 
-const int MAX_SAMPLE_RATE   = 100000;
+const int MAX_SAMPLE_RATE   = 200000;
 const int MAX_ZOOM          = 2000000;
 const double MAX_START_TIME = 12 * 60 * 60; // 12 hours
 

--- a/test/GdImageRendererTest.cpp
+++ b/test/GdImageRendererTest.cpp
@@ -184,7 +184,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfImageHeightIsLessThanMinimum)
 TEST_F(GdImageRendererTest, shouldReportErrorIfSampleRateIsTooHigh)
 {
     WaveformBuffer buffer;
-    buffer.setSampleRate(100001);
+    buffer.setSampleRate(200001);
     buffer.setSamplesPerPixel(64);
 
     const WaveformColors& colors = audacity_waveform_colors;
@@ -205,7 +205,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfSampleRateIsTooHigh)
 TEST_F(GdImageRendererTest, shouldReportErrorIfScaleIsTooHigh)
 {
     WaveformBuffer buffer;
-    buffer.setSampleRate(100000);
+    buffer.setSampleRate(200000);
     buffer.setSamplesPerPixel(2000001);
 
     const WaveformColors& colors = audacity_waveform_colors;

--- a/test/GdImageRendererTest.cpp
+++ b/test/GdImageRendererTest.cpp
@@ -184,7 +184,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfImageHeightIsLessThanMinimum)
 TEST_F(GdImageRendererTest, shouldReportErrorIfSampleRateIsTooHigh)
 {
     WaveformBuffer buffer;
-    buffer.setSampleRate(50001);
+    buffer.setSampleRate(100001);
     buffer.setSamplesPerPixel(64);
 
     const WaveformColors& colors = audacity_waveform_colors;
@@ -205,7 +205,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfSampleRateIsTooHigh)
 TEST_F(GdImageRendererTest, shouldReportErrorIfScaleIsTooHigh)
 {
     WaveformBuffer buffer;
-    buffer.setSampleRate(50000);
+    buffer.setSampleRate(100000);
     buffer.setSamplesPerPixel(2000001);
 
     const WaveformColors& colors = audacity_waveform_colors;


### PR DESCRIPTION
Changed occurrences of 50000 max sample rate constant to 200000 (and made the same change in the tests). Functionality works as expected on 192kHz sample rate audio files at very low pixel/sample ratios.