### PR TITLE
Read from STDIN. Assume WAV format

### DIFF
--- a/src/OptionHandler.cpp
+++ b/src/OptionHandler.cpp
@@ -50,7 +50,7 @@ static std::unique_ptr<AudioFileReader> createAudioFileReader(
 
     const boost::filesystem::path ext = filename.extension();
 
-    if (ext == ".wav" || ext == ".flac") {
+    if (ext == ".wav" || ext == ".flac" || filename == "-") {
         reader.reset(new SndFileAudioFileReader);
     }
     else if (ext == ".mp3") {
@@ -358,7 +358,8 @@ bool OptionHandler::run(const Options& options)
         }
         else if ((input_file_ext == ".mp3" ||
                   input_file_ext == ".wav" ||
-                  input_file_ext == ".flac") &&
+                  input_file_ext == ".flac" ||
+                  input_filename == "-") &&
                  (output_file_ext == ".dat" || output_file_ext == ".json")) {
             success = generateWaveformData(
                 input_filename,

--- a/src/SndFileAudioFileReader.cpp
+++ b/src/SndFileAudioFileReader.cpp
@@ -61,7 +61,10 @@ SndFileAudioFileReader::~SndFileAudioFileReader()
 
 bool SndFileAudioFileReader::open(const char* input_filename)
 {
-    input_file_ = sf_open(input_filename, SFM_READ, &info_);
+    if (input_filename[0] == '-' && input_filename[1] == '\0')
+        input_file_ = sf_open_fd(0, SFM_READ, &info_, 0);
+    else
+        input_file_ = sf_open(input_filename, SFM_READ, &info_);
 
     if (input_file_ != nullptr) {
         output_stream << "Input file: " << input_filename << std::endl;


### PR DESCRIPTION
A crude, but works, solution to reading from stdin. WAV/FLAC format is assumed.
A pipe from ffmpeg generates exactly the same output as the ffmpeg-encoded file.
I opted for the same read from stdin syntax that ffmpeg uses. Input filename denoted as a dash.

Example:
```
ffmpeg -i test.mp4 -f wav - | audiowaveform -i - -o test.dat
```

Possible solution for issue #13

I invite anyone to improve my idea if they so wish to make it more robust. For now, this works for my use case, so I doubt I will work on it any further. I will try to work on it in my spare time if any more changes are requested for a merge.