### PR TITLE
Ubuntu 18.04 package requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,16 @@ not already done so.
     $ sudo yum install git make cmake gcc-c++ libmad-devel \
       libid3tag-devel libsndfile-devel gd-devel boost-devel
 
-#### Ubuntu
+#### Ubuntu < 18.04
 
     $ sudo apt-get install git make cmake gcc g++ libmad0-dev \
       libid3tag0-dev libsndfile1-dev libgd2-xpm-dev libboost-filesystem-dev \
+      libboost-program-options-dev \
+      libboost-regex-dev
+      
+#### Ubuntu >= 18.04
+    $ sudo apt-get install git make cmake gcc g++ libmad0-dev \
+      libid3tag0-dev libsndfile1-dev libgd-dev libboost-filesystem-dev \
       libboost-program-options-dev \
       libboost-regex-dev
 


### PR DESCRIPTION
I noticed in Ubuntu 17.10, when installing `libgd2-xpm-dev`, it says: `Note, selecting 'libgd-dev' instead of 'libgd2-xpm-dev'` and on 18.04, `libgd2-xpm-dev` is not found, but `libgd-dev` installs and audiowaveform compiles without errors.