### PR TITLE
Updates to details around Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,7 @@ operating system releases.
 
 #### Fedora
 
-libmad is available from the RPM Fusion **free** repository. Before running the
-following `yum` command you should follow the instructions
-[here](http://rpmfusion.org/Configuration) to add this repository, if you have
-not already done so.
-
-    $ sudo yum install git make cmake gcc-c++ libmad-devel \
+    $ sudo dnf install git make cmake gcc-c++ libmad-devel \
       libid3tag-devel libsndfile-devel gd-devel boost-devel
 
 #### Ubuntu


### PR DESCRIPTION
With the mp3 patents expiring libmad is now distributed in all recent releases of Fedora
so there's no need to add the RPM Fusion repositories. Update the command to install
the development packages to the current standard.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>