### PR TITLE
Feature request: Ability to have much less samples

### DIFF
--- a/src/DurationCalculator.cpp
+++ b/src/DurationCalculator.cpp
@@ -72,3 +72,9 @@ double DurationCalculator::getDuration() const
 }
 
 //------------------------------------------------------------------------------
+
+long DurationCalculator::getFrameCount() const {
+    return frame_count_;
+}
+
+//------------------------------------------------------------------------------

--- a/src/DurationCalculator.h
+++ b/src/DurationCalculator.h
@@ -53,6 +53,8 @@ class DurationCalculator : public AudioProcessor
 
         double getDuration() const;
 
+        long getFrameCount() const;
+
     private:
         int sample_rate_;
         long frame_count_;

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -54,6 +54,8 @@ Options::Options() :
     has_samples_per_pixel_(false),
     pixels_per_second_(0),
     has_pixels_per_second_(false),
+    pixels_count_(0),
+    has_pixels_count_(false),
     image_width_(0),
     image_height_(0),
     bits_(16),
@@ -117,6 +119,10 @@ bool Options::parseCommandLine(int argc, const char* const* argv)
         "pixels-per-second",
         po::value<int>(&pixels_per_second_)->default_value(100),
         "zoom level (pixels per second)"
+    )(
+        "pixels-count",
+        po::value<int>(&pixels_count_)->default_value(10000),
+        "zoom level (pixels count)"
     )(
         "bits,b",
         po::value<int>(&bits_)->default_value(16),
@@ -195,6 +201,7 @@ bool Options::parseCommandLine(int argc, const char* const* argv)
 
         has_samples_per_pixel_ = !variables_map["zoom"].defaulted();
         has_pixels_per_second_ = !variables_map["pixels-per-second"].defaulted();
+        has_pixels_count_ = !variables_map["pixels-count"].defaulted();
 
         has_bits_ = !variables_map["bits"].defaulted();
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -84,6 +84,9 @@ class Options
         int getPixelsPerSecond() const { return pixels_per_second_; }
         bool hasPixelsPerSecond() const { return has_pixels_per_second_; }
 
+        int getPixelsCount() const { return pixels_count_; }
+        bool hasPixelsCount() const { return has_pixels_count_; }
+
         int getBits() const { return bits_; }
         bool hasBits() const { return has_bits_; }
         int getImageWidth() const { return image_width_; }
@@ -149,6 +152,9 @@ class Options
 
         int pixels_per_second_;
         bool has_pixels_per_second_;
+
+        int pixels_count_;
+        bool has_pixels_count_;
 
         int image_width_;
         int image_height_;

--- a/src/WaveformGenerator.cpp
+++ b/src/WaveformGenerator.cpp
@@ -128,8 +128,7 @@ PixelScaleFactor::PixelScaleFactor(int pixels_count, long frames_count) :
 int PixelScaleFactor::getSamplesPerPixel(int /*sample_rate*/) const
 {
     return static_cast<int>(frames_count_ / pixels_count_ +
-            (frames_count_ % pixels_count_ > 0 ? 1 : 0));
-
+            ((frames_count_ % pixels_count_) > 0 ? 1 : 0));
 }
 
 //------------------------------------------------------------------------------

--- a/src/WaveformGenerator.cpp
+++ b/src/WaveformGenerator.cpp
@@ -110,6 +110,30 @@ int PixelsPerSecondScaleFactor::getSamplesPerPixel(int sample_rate) const
 
 //------------------------------------------------------------------------------
 
+PixelScaleFactor::PixelScaleFactor(int pixels_count, long frames_count) :
+        pixels_count_(pixels_count),
+        frames_count_(frames_count)
+{
+    if (pixels_count_ <= 0) {
+        throwError("Invalid pixels count: must be greater than zero");
+    }
+
+    if (frames_count_ <= 0) {
+        throwError("Invalid frames count: must be greater than zero");
+    }
+}
+
+//------------------------------------------------------------------------------
+
+int PixelScaleFactor::getSamplesPerPixel(int /*sample_rate*/) const
+{
+    return static_cast<int>(frames_count_ / pixels_count_ +
+            (frames_count_ % pixels_count_ > 0 ? 1 : 0));
+
+}
+
+//------------------------------------------------------------------------------
+
 const int MAX_SAMPLE = std::numeric_limits<short>::max();
 const int MIN_SAMPLE = std::numeric_limits<short>::min();
 

--- a/src/WaveformGenerator.h
+++ b/src/WaveformGenerator.h
@@ -95,6 +95,20 @@ class DurationScaleFactor : public ScaleFactor
 
 //------------------------------------------------------------------------------
 
+class PixelScaleFactor : public ScaleFactor
+{
+public:
+    PixelScaleFactor(int pixels_count, long frames_count);
+
+public:
+    virtual int getSamplesPerPixel(int sample_rate) const;
+
+private:
+    int pixels_count_;
+    long frames_count_;
+};
+
+//------------------------------------------------------------------------------
 class WaveformGenerator : public AudioProcessor
 {
     public:


### PR DESCRIPTION
At this moment I'm not shure how to write tests for it.
Feature will give you the the possibility to set maximum number of pixels on the output files. In order to achive it we need to take number of all frames (frame is block of samples, one for each channel) and devide it by desired number of pixels. We will receive then samples per pixel. But since samples per pixel is integer,  higher values of desired number of pixels can get the SAME number of samples per pixel. Consider this example, based on test_file_mono.wav:
It has 113519 of frames. Let's say i want to 376 samples.
```
samples_per_pixel1 = static_cast<int>(frames_count_ / pixels_count_ +
            ((frames_count_ % pixels_count_) > 0 ? 1 : 0)); // =302 double is 301.9122
```
Now, let's say i want to 377 samples.
```
samples_per_pixel2 = static_cast<int>(frames_count_ / pixels_count_ +
            ((frames_count_ % pixels_count_) > 0 ? 1 : 0)); // ALSO =302 !! double is 301.1114
```

Thus we are able to set precisly pixels count till the diferrence between these to samples_per_pixel1 - samples_per_pixel2 is greater than 1. The higher the pixels-count the more often you will encounter lower values than given the maximum.