### PR TITLE
Bar customization for PNG

### DIFF
--- a/src/GdImageRenderer.h
+++ b/src/GdImageRenderer.h
@@ -71,6 +71,7 @@ class GdImageRenderer
         void drawBorder() const;
 
         void drawWaveform(const WaveformBuffer& buffer) const;
+        void drawRoundedRectangle(const int x1, const int y1, const int x2, const int y2, const int radius) const;
 
         void drawTimeAxisLabels() const;
 


### PR DESCRIPTION
## 🔥✨

Addressing [Issue 111](https://github.com/bbc/audiowaveform/issues/111)
- Generate rounded radius
- Add space between bars

## 🤖 🤞
```shell
./audiowaveform -i ../path/to/audio.mp3 -o ../path/to/audio.png --end 211 -w 8000 -h 200 --no-axis-labels --background-color 00000000 --waveform-color EF5350FF --border-color 00000000
```

Output

![image](https://user-images.githubusercontent.com/13006409/77912226-7744a300-7292-11ea-9872-207565044023.png)

## ❌ ✋


TODO:
- Set the customizations as argument instead of hardcoding them
- Fix: not whole waveform is generated (the incrementation is wrong)

