### PR TITLE
Add wave bars customization options

### DIFF
--- a/src/GdImageRenderer.cpp
+++ b/src/GdImageRenderer.cpp
@@ -283,7 +283,7 @@ void GdImageRenderer::drawWaveform(const WaveformBuffer& buffer) const
             int low_y  = waveform_top_y + height - 1 - low  * height / 65536;
 
             if (bar_width_ > 1) {
-                drawRoundedRectangle(x, high_y, x + bar_width_, low_y, radius);
+                drawRoundedRectangle(x, high_y, x + bar_width_ - 1, low_y, radius);
             }
             else {
                 gdImageLine(image_, x, low_y, x, high_y, waveform_color_);

--- a/src/GdImageRenderer.cpp
+++ b/src/GdImageRenderer.cpp
@@ -34,6 +34,7 @@
 #include <gdfonts.h>
 
 #include <cassert>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <iomanip>

--- a/src/GdImageRenderer.cpp
+++ b/src/GdImageRenderer.cpp
@@ -125,8 +125,6 @@ bool GdImageRenderer::create(
         return false;
     }
 
-    image_ = gdImageCreateTrueColor(image_width, image_height);
-
     if (image_ == nullptr) {
         log(Error) << "Failed to create image\n";
         return false;
@@ -285,7 +283,7 @@ void GdImageRenderer::drawWaveform(const WaveformBuffer& buffer) const
             int high_y = waveform_top_y + height - 1 - high * height / 65536;
             int low_y  = waveform_top_y + height - 1 - low  * height / 65536;
 
-            if ( waveform_style_bars_ ) {
+            if (waveform_style_bars_) {
                 const int barMiddleY = (low_y - high_y) / 2 + high_y;
                 const int distanceFromMiddleY = imageMiddleY - barMiddleY;
 
@@ -305,9 +303,14 @@ void GdImageRenderer::drawWaveform(const WaveformBuffer& buffer) const
     }
 }
 
-void GdImageRenderer::drawRoundedRectangle(const int x1, const int y1, const int x2, const int y2, const float radius) const
+void GdImageRenderer::drawRoundedRectangle(
+    const int x1,
+    const int y1,
+    const int x2,
+    const int y2,
+    const float radius) const
  {
-    if( !bar_style_rounded_) {
+    if(!bar_style_rounded_) {
         gdImageFilledRectangle(image_, x1, y1, x2, y2, waveform_color_);
         return;    
     }
@@ -315,7 +318,7 @@ void GdImageRenderer::drawRoundedRectangle(const int x1, const int y1, const int
     double rad = fmin(radius, floor(fmin((x2 - x1) / 2, (y2 - y1) / 2)));
     int width = x2 - x1;
 
-    if ( rad != 0 && rad * 2 != width ) {
+    if (rad != 0 && rad * 2 != width) {
         // We need to fill the gap between the individual radiuses
         gdImageFilledRectangle(
             image_,

--- a/src/GdImageRenderer.cpp
+++ b/src/GdImageRenderer.cpp
@@ -271,20 +271,27 @@ void GdImageRenderer::drawWaveform(const WaveformBuffer& buffer) const
         }
 
         const int height = waveform_bottom_y - waveform_top_y + 1;
+        const int imageMiddleY = height / 2;
         for (int i = start_index, x = start_x; i < buffer_size; ++i) {
             if (x + bar_width_ > max_x) {
                 break;
             }
 
             // Convert range [-32768, 32727] to [0, 65535]
-            int low  = MathUtil::scale(buffer.getMinSample(channel, i), amplitude_scale) + 32768;
-            int high = MathUtil::scale(buffer.getMaxSample(channel, i), amplitude_scale) + 32768;
+            const int low  = MathUtil::scale(buffer.getMinSample(channel, i), amplitude_scale) + 32768;
+            const int high = MathUtil::scale(buffer.getMaxSample(channel, i), amplitude_scale) + 32768;
 
             // Scale to fit the bitmap
             int high_y = waveform_top_y + height - 1 - high * height / 65536;
             int low_y  = waveform_top_y + height - 1 - low  * height / 65536;
 
             if ( waveform_style_bars_ ) {
+                const int barMiddleY = (low_y - high_y) / 2 + high_y;
+                const int distanceFromMiddleY = imageMiddleY - barMiddleY;
+
+                high_y += distanceFromMiddleY;
+                low_y += distanceFromMiddleY;
+
                 drawRoundedRectangle(x, high_y, x + bar_width_ - 1, low_y - 1, radius);
                 x += bar_width_ + bar_gap_;
             } else {

--- a/src/GdImageRenderer.cpp
+++ b/src/GdImageRenderer.cpp
@@ -270,7 +270,9 @@ void GdImageRenderer::drawWaveform(const WaveformBuffer& buffer) const
         const int height = waveform_bottom_y - waveform_top_y + 1;
 
         for (int i = start_index, x = start_x; i < buffer_size; ++i) {
-            if ( x + bar_width_ > max_x ) { break; }
+            if (x + bar_width_ > max_x) {
+                break;
+            }
 
             // Convert range [-32768, 32727] to [0, 65535]
             int low  = MathUtil::scale(buffer.getMinSample(channel, i), amplitude_scale) + 32768;
@@ -280,9 +282,10 @@ void GdImageRenderer::drawWaveform(const WaveformBuffer& buffer) const
             int high_y = waveform_top_y + height - 1 - high * height / 65536;
             int low_y  = waveform_top_y + height - 1 - low  * height / 65536;
 
-            if ( bar_width_ > 1 ) {
+            if (bar_width_ > 1) {
                 drawRoundedRectangle(x, high_y, x + bar_width_, low_y, radius);
-            } else {
+            }
+            else {
                 gdImageLine(image_, x, low_y, x, high_y, waveform_color_);
             }
 
@@ -294,15 +297,41 @@ void GdImageRenderer::drawWaveform(const WaveformBuffer& buffer) const
     }
 }
 
-void GdImageRenderer::drawRoundedRectangle(const int x1, const int y1, const int x2, const int y2, const int radius) const
- {
+void GdImageRenderer::drawRoundedRectangle(
+    const int x1,
+    const int y1,
+    const int x2,
+    const int y2,
+    const int radius) const
+{
     gdImageFilledRectangle(image_, x1, y1, x2, y2, waveform_color_);
 
-    if( bar_style_rounded_) {
-        gdImageFilledArc(image_, x1 + radius, y1, radius * 2, radius, 180, 360, waveform_color_, gdStyledBrushed);
-        gdImageFilledArc(image_, x1 + radius, y2, radius * 2, radius, 0, 180, waveform_color_, gdStyledBrushed);
+    if (bar_style_rounded_) {
+        gdImageFilledArc(
+            image_,
+            x1 + radius,
+            y1,
+            radius * 2,
+            radius,
+            180,
+            360,
+            waveform_color_,
+            gdStyledBrushed
+        );
+
+        gdImageFilledArc(
+            image_,
+            x1 + radius,
+            y2,
+            radius * 2,
+            radius,
+            0,
+            180,
+            waveform_color_,
+            gdStyledBrushed
+        );
     }
- }
+}
 
 //------------------------------------------------------------------------------
 

--- a/src/GdImageRenderer.cpp
+++ b/src/GdImageRenderer.cpp
@@ -310,17 +310,81 @@ void GdImageRenderer::drawRoundedRectangle(const int x1, const int y1, const int
 
     if ( rad != 0 && rad * 2 != width ) {
         // We need to fill the gap between the individual radiuses
-        gdImageFilledRectangle(image_, x1 + rad, y1, x2 - rad, y1 + rad, waveform_color_);
-        gdImageFilledRectangle(image_, x1 + rad, y2 - rad, x2 - rad, y2, waveform_color_);
+        gdImageFilledRectangle(
+            image_,
+            (int)(x1 + rad),
+            y1,
+            (int)(x2 - rad),
+            (int)(y1 + rad),
+            waveform_color_
+        );
+        gdImageFilledRectangle(
+            image_,
+            (int)(x1 + rad),
+            (int)(y2 - rad),
+            (int)(x2 - rad),
+            y2,
+            waveform_color_
+        );
     }
     
     // Drawing the arcs
-    gdImageFilledArc(image_, x1 + rad, y1 + rad, rad * 2, rad * 2, 180, 270, waveform_color_, gdStyledBrushed); // top left radius
-    gdImageFilledArc(image_, x2 - rad, y1 + rad, rad * 2, rad * 2, 270, 0, waveform_color_, gdStyledBrushed); // top right radius
-    gdImageFilledArc(image_, x2 - rad, y2 - rad, rad * 2, rad * 2, 0, 90, waveform_color_, gdStyledBrushed); // bottom right radius
-    gdImageFilledArc(image_, x1 + rad, y2 - rad, rad * 2, rad * 2, 90, 180, waveform_color_, gdStyledBrushed); // bottom left
+    gdImageFilledArc(
+        image_,
+        (int)(x1 + rad),
+        (int)(y1 + rad),
+        (int)(rad * 2),
+        (int)(rad * 2),
+        180,
+        270,
+        waveform_color_,
+        gdStyledBrushed
+    ); // top left radius
 
-    gdImageFilledRectangle(image_, x1, y1 + rad, x2, y2 - rad, waveform_color_);
+    gdImageFilledArc(
+        image_,
+        (int)(x2 - rad),
+        (int)(y1 + rad),
+        (int)(rad * 2),
+        (int)(rad * 2),
+        270,
+        0,
+        waveform_color_,
+        gdStyledBrushed
+    ); // top right radius
+
+    gdImageFilledArc(
+        image_,
+        (int)(x2 - rad),
+        (int)(y2 - rad),
+        (int)(rad * 2),
+        (int)(rad * 2),
+        0,
+        90,
+        waveform_color_,
+        gdStyledBrushed
+    ); // bottom right radius
+
+    gdImageFilledArc(
+        image_,
+        (int)(x1 + rad),
+        (int)(y2 - rad),
+        (int)(rad * 2),
+        (int)(rad * 2),
+        90,
+        180,
+        waveform_color_,
+        gdStyledBrushed
+    ); // bottom left
+
+    gdImageFilledRectangle(
+        image_,
+        x1,
+        (int)(y1 + rad),
+        x2,
+        (int)(y2 - rad),
+        waveform_color_
+    );
  }
 
 //------------------------------------------------------------------------------

--- a/src/GdImageRenderer.cpp
+++ b/src/GdImageRenderer.cpp
@@ -130,8 +130,6 @@ bool GdImageRenderer::create(
         return false;
     }
 
-    image_ = gdImageCreateTrueColor(image_width, image_height);
-
     assert(sample_rate != 0);
     assert(samples_per_pixel != 0);
 

--- a/src/GdImageRenderer.h
+++ b/src/GdImageRenderer.h
@@ -52,6 +52,7 @@ class GdImageRenderer
             int image_width,
             int image_height,
             const WaveformColors& colors,
+            bool waveform_style_bars,
             int bar_width,
             int bar_gap,
             bool bar_style_rounded,
@@ -74,14 +75,7 @@ class GdImageRenderer
         void drawBorder() const;
 
         void drawWaveform(const WaveformBuffer& buffer) const;
-
-        void drawRoundedRectangle(
-            const int x1,
-            const int y1,
-            const int x2,
-            const int y2,
-            const int radius
-        ) const;
+        void drawRoundedRectangle(const int x1, const int y1, const int x2, const int y2, const float radius) const;
 
         void drawTimeAxisLabels() const;
 
@@ -111,6 +105,7 @@ class GdImageRenderer
         int waveform_color_;
         int axis_label_color_;
 
+        bool waveform_style_bars_;
         int bar_width_;
         int bar_gap_;
         bool bar_style_rounded_;

--- a/src/GdImageRenderer.h
+++ b/src/GdImageRenderer.h
@@ -75,7 +75,12 @@ class GdImageRenderer
         void drawBorder() const;
 
         void drawWaveform(const WaveformBuffer& buffer) const;
-        void drawRoundedRectangle(const int x1, const int y1, const int x2, const int y2, const float radius) const;
+        void drawRoundedRectangle(
+            const int x1,
+            const int y1,
+            const int x2,
+            const int y2,
+            const float radius) const;
 
         void drawTimeAxisLabels() const;
 

--- a/src/GdImageRenderer.h
+++ b/src/GdImageRenderer.h
@@ -52,6 +52,9 @@ class GdImageRenderer
             int image_width,
             int image_height,
             const WaveformColors& colors,
+            int bar_width,
+            int bar_gap,
+            bool bar_style_rounded,
             bool render_axis_labels,
             bool auto_amplitude_scale,
             double amplitude_scale
@@ -71,6 +74,7 @@ class GdImageRenderer
         void drawBorder() const;
 
         void drawWaveform(const WaveformBuffer& buffer) const;
+        void drawRoundedRectangle(const int x1, const int y1, const int x2, const int y2, const int radius) const;
 
         void drawTimeAxisLabels() const;
 
@@ -99,6 +103,10 @@ class GdImageRenderer
         int background_color_;
         int waveform_color_;
         int axis_label_color_;
+
+        int bar_width_;
+        int bar_gap_;
+        bool bar_style_rounded_;
 
         bool render_axis_labels_;
 

--- a/src/GdImageRenderer.h
+++ b/src/GdImageRenderer.h
@@ -74,7 +74,14 @@ class GdImageRenderer
         void drawBorder() const;
 
         void drawWaveform(const WaveformBuffer& buffer) const;
-        void drawRoundedRectangle(const int x1, const int y1, const int x2, const int y2, const int radius) const;
+
+        void drawRoundedRectangle(
+            const int x1,
+            const int y1,
+            const int x2,
+            const int y2,
+            const int radius
+        ) const;
 
         void drawTimeAxisLabels() const;
 

--- a/src/OptionHandler.cpp
+++ b/src/OptionHandler.cpp
@@ -493,6 +493,9 @@ bool OptionHandler::renderWaveformImage(
         options.getImageWidth(),
         options.getImageHeight(),
         colors,
+        options.getBarWidth(),
+        options.getBarGap(),
+        options.isBarStyleRounded(),
         options.getRenderAxisLabels(),
         options.isAutoAmplitudeScale(),
         options.getAmplitudeScale()))

--- a/src/OptionHandler.cpp
+++ b/src/OptionHandler.cpp
@@ -493,6 +493,7 @@ bool OptionHandler::renderWaveformImage(
         options.getImageWidth(),
         options.getImageHeight(),
         colors,
+        options.isWaveFormStyleBars(),
         options.getBarWidth(),
         options.getBarGap(),
         options.isBarStyleRounded(),

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -60,6 +60,9 @@ Options::Options() :
     image_height_(0),
     bits_(16),
     has_bits_(false),
+    bar_width_(1),
+    bar_gap_(0),
+    bar_style_rounded_(false),
     render_axis_labels_(true),
     auto_amplitude_scale_(false),
     amplitude_scale_(1.0),
@@ -162,6 +165,18 @@ bool Options::parseCommandLine(int argc, const char* const* argv)
         "waveform-color",
         po::value<RGBA>(&waveform_color_),
         "wave color (rrggbb[aa])"
+    )(
+        "bar-width",
+        po::value<int>(&bar_width_)->default_value(1),
+        "bar width (pixels)"
+    )(
+        "bar-gap",
+        po::value<int>(&bar_gap_)->default_value(0),
+        "bar gap (pixels)"
+    )(
+        "bar-style-rounded",
+        po::value<bool>(&bar_style_rounded_)->default_value(false),
+        "bar style rounded (default to square)"
     )(
         "axis-label-color",
         po::value<RGBA>(&axis_label_color_),

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -166,6 +166,10 @@ bool Options::parseCommandLine(int argc, const char* const* argv)
         po::value<RGBA>(&waveform_color_),
         "wave color (rrggbb[aa])"
     )(
+        "waveform-style-bars",
+        po::value<bool>(&waveform_style_bars_)->default_value(false),
+        "waveform style bars (default to normal))"
+    )(
         "bar-width",
         po::value<int>(&bar_width_)->default_value(1),
         "bar width (pixels)"

--- a/src/Options.h
+++ b/src/Options.h
@@ -103,6 +103,7 @@ class Options
 
         bool getRenderAxisLabels() const { return render_axis_labels_; }
 
+        bool isWaveFormStyleBars() const { return waveform_style_bars_; }
         int getBarWidth() const { return bar_width_; }
         int getBarGap() const { return bar_gap_; }
         bool isBarStyleRounded() const { return bar_style_rounded_; }
@@ -169,6 +170,7 @@ class Options
         RGBA waveform_color_;
         RGBA axis_label_color_;
 
+        bool waveform_style_bars_;
         int bar_width_;
         int bar_gap_;
         bool bar_style_rounded_;

--- a/src/Options.h
+++ b/src/Options.h
@@ -103,6 +103,10 @@ class Options
 
         bool getRenderAxisLabels() const { return render_axis_labels_; }
 
+        int getBarWidth() const { return bar_width_; }
+        int getBarGap() const { return bar_gap_; }
+        bool isBarStyleRounded() const { return bar_style_rounded_; }
+
         bool isAutoAmplitudeScale() const { return auto_amplitude_scale_; }
         double getAmplitudeScale() const { return amplitude_scale_; }
 
@@ -164,6 +168,10 @@ class Options
         RGBA background_color_;
         RGBA waveform_color_;
         RGBA axis_label_color_;
+
+        int bar_width_;
+        int bar_gap_;
+        bool bar_style_rounded_;
 
         bool has_border_color_;
         bool has_background_color_;

--- a/test/GdImageRendererTest.cpp
+++ b/test/GdImageRendererTest.cpp
@@ -77,7 +77,7 @@ void GdImageRendererTest::testImageRendering(bool axis_labels, const std::string
     const WaveformColors& colors = audacity_waveform_colors;
 
     GdImageRenderer renderer;
-    result = renderer.create(buffer, 5.0, 1000, 300, colors, axis_labels, false, 1.0); // zoom: 128
+    result = renderer.create(buffer, 5.0, 1000, 300, colors, 1, 0, false, axis_labels, false, 1.0); // zoom: 128
     ASSERT_TRUE(result);
 
     result = renderer.saveAsPng(filename.c_str());
@@ -159,7 +159,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfImageWidthIsLessThanMinimum)
     const WaveformColors& colors = audacity_waveform_colors;
 
     GdImageRenderer renderer;
-    bool result = renderer.create(buffer, 5.0, 0, 300, colors, true, false, 1.0);
+    bool result = renderer.create(buffer, 5.0, 0, 300, colors, 1, 0, false, true, false, 1.0);
 
     ASSERT_FALSE(result);
     ASSERT_TRUE(output.str().empty());
@@ -179,7 +179,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfImageHeightIsLessThanMinimum)
     const WaveformColors& colors = audacity_waveform_colors;
 
     GdImageRenderer renderer;
-    bool result = renderer.create(buffer, 5.0, 800, 0, colors, true, false, 1.0);
+    bool result = renderer.create(buffer, 5.0, 800, 0, colors, 1, 0, false, true, false, 1.0);
 
     ASSERT_FALSE(result);
     ASSERT_TRUE(output.str().empty());
@@ -199,7 +199,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfSampleRateIsZero)
     const WaveformColors& colors = audacity_waveform_colors;
 
     GdImageRenderer renderer;
-    bool result = renderer.create(buffer, 5.0, 800, 250, colors, true, false, 1.0);
+    bool result = renderer.create(buffer, 5.0, 800, 250, colors, 1, 0, false, true, false, 1.0);
 
     ASSERT_FALSE(result);
     ASSERT_TRUE(output.str().empty());
@@ -219,7 +219,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfSampleRateIsNegative)
     const WaveformColors& colors = audacity_waveform_colors;
 
     GdImageRenderer renderer;
-    bool result = renderer.create(buffer, 5.0, 800, 250, colors, true, false, 1.0);
+    bool result = renderer.create(buffer, 5.0, 800, 250, colors, 1, 0, false, true, false, 1.0);
 
     ASSERT_FALSE(result);
     ASSERT_TRUE(output.str().empty());
@@ -239,7 +239,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfScaleIsZero)
     const WaveformColors& colors = audacity_waveform_colors;
 
     GdImageRenderer renderer;
-    bool result = renderer.create(buffer, 5.0, 800, 250, colors, true, false, 1.0);
+    bool result = renderer.create(buffer, 5.0, 800, 250, colors, 1, 0, false, true, false, 1.0);
 
     ASSERT_FALSE(result);
     ASSERT_TRUE(output.str().empty());
@@ -259,7 +259,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfScaleIsNegative)
     const WaveformColors& colors = audacity_waveform_colors;
 
     GdImageRenderer renderer;
-    bool result = renderer.create(buffer, 5.0, 800, 250, colors, true, false, 1.0);
+    bool result = renderer.create(buffer, 5.0, 800, 250, colors, 1, 0, false, true, false, 1.0);
 
     ASSERT_FALSE(result);
     ASSERT_TRUE(output.str().empty());
@@ -278,7 +278,7 @@ TEST_F(GdImageRendererTest, shouldReportErrorIfWaveformBufferIsEmpty)
     const WaveformColors& colors = audacity_waveform_colors;
 
     GdImageRenderer renderer;
-    bool result = renderer.create(buffer, 5.0, 800, 250, colors, true, false, 1.0);
+    bool result = renderer.create(buffer, 5.0, 800, 250, colors, 1, 0, false, true, false, 1.0);
 
     ASSERT_FALSE(result);
     ASSERT_TRUE(output.str().empty());


### PR DESCRIPTION
Addressing [issue 111](https://github.com/bbc/audiowaveform/issues/111)

- Add bar width (pixels)
- Add bar gap (pixels)
- Add bar style rounded (true/false)

FYI: I did not implement `waveform-style`, it's simply determined by the bar width option

`./audiowaveform -i ./path/to/audio.mp3 -o ./path/to/audio.png -w 896 -h 184 --no-axis-labels --background-color "00000000" --waveform-color EF5350FF --bar-width 8 --bar-gap 4 --bar-style-rounded true --pixels-per-second 5`

Output
![test](https://github.com/bbc/audiowaveform/assets/171186/3f837bde-7848-405d-8a6e-7f6ab4c49898)

