### PR TITLE
Add release packages for Debian 13

### DIFF
--- a/rpm/build_all.sh
+++ b/rpm/build_all.sh
@@ -10,6 +10,8 @@ source ./cmdline.sh
 ./build_deb_debian.sh -v ${AUDIOWAVEFORM_PACKAGE_VERSION} -c ${AUDIOWAVEFORM_VERSION} -d 11 -a arm64
 ./build_deb_debian.sh -v ${AUDIOWAVEFORM_PACKAGE_VERSION} -c ${AUDIOWAVEFORM_VERSION} -d 12 -a amd64
 ./build_deb_debian.sh -v ${AUDIOWAVEFORM_PACKAGE_VERSION} -c ${AUDIOWAVEFORM_VERSION} -d 12 -a arm64
+./build_deb_debian.sh -v ${AUDIOWAVEFORM_PACKAGE_VERSION} -c ${AUDIOWAVEFORM_VERSION} -d 13 -a amd64
+./build_deb_debian.sh -v ${AUDIOWAVEFORM_PACKAGE_VERSION} -c ${AUDIOWAVEFORM_VERSION} -d 13 -a arm64
 ./build_rpm_centos7.sh -v ${AUDIOWAVEFORM_PACKAGE_VERSION} -c ${AUDIOWAVEFORM_VERSION} -a x86_64
 ./build_rpm_centos7.sh -v ${AUDIOWAVEFORM_PACKAGE_VERSION} -c ${AUDIOWAVEFORM_VERSION} -a aarch64
 ./build_rpm_centos8.sh -v ${AUDIOWAVEFORM_PACKAGE_VERSION} -c ${AUDIOWAVEFORM_VERSION} -a x86_64

--- a/rpm/build_deb_debian.sh
+++ b/rpm/build_deb_debian.sh
@@ -9,7 +9,7 @@ source ./cmdline.sh
 
 if [ -z "${DEBIAN_RELEASE}" ]
 then
-    echo "Missing debian release number (e.g., 10, 11, or 12)"
+    echo "Missing debian release number (e.g., 10, 11, 12, or 13)"
     exit 1
 fi
 


### PR DESCRIPTION
Hi Chris, 

Debian 13 has now launched, see https://www.debian.org/News/2025/20250809

This PR adds Debian builds for version 13 to the package build script.